### PR TITLE
Convert email and phone to MultaccItem

### DIFF
--- a/lib/items/email.dart
+++ b/lib/items/email.dart
@@ -1,0 +1,25 @@
+import 'package:contacts_service/contacts_service.dart';
+
+import 'item.dart';
+
+class EmailItem extends MultaccItem {
+  String email;
+
+  EmailItem.fromJson(Map<String, dynamic> json) : email = json['email'];
+
+  EmailItem.fromItem(Item item) : email = item.toString();
+
+  Map<String, dynamic> toJson() => {'email': email};
+
+  String getHumanReadableType() => 'Email';
+
+  String getHumanReadableValue() => email;
+
+  MultaccItemType getType() => MultaccItemType.Email;
+
+  void launchApp() {
+    // @todo Implement email launching
+  }
+
+  bool isLaunchable() => true;
+}

--- a/lib/items/item.dart
+++ b/lib/items/item.dart
@@ -5,7 +5,7 @@ abstract class MultaccItem {
   /// Multacc item key for database
   String key;
 
-  MultaccItem(): key = null;
+  MultaccItem() : key = null;
 
   /// Use this constructor to create a MultaccItem using database values
   factory MultaccItem.fromDB(String key, int typeInt, Map<String, dynamic> json) {
@@ -60,14 +60,18 @@ abstract class MultaccItem {
   /// Get human-readable item type (Snapchat, etc.) to display
   String getHumanReadableValue();
 
-  // @todo Frontend team should add something like getIcon to MultaccItem
+// @todo Frontend team should add something like getIcon to MultaccItem
 }
 
+// To maintain the relationship between type and enum index, never remove things from this enum and always add new
+// things at the end pls kthx
 enum MultaccItemType {
   Twitter,
   Snapchat, // @todo Implement snapchat
   Instagram, // @todo Implement instagram
   Facebook, // @todo Implement facebook
   Discord, // @todo Implement discord
-  Dogecoin // @todo Implement dogecoin
+  Dogecoin, // @todo Implement dogecoin
+  Phone,
+  Email
 }

--- a/lib/items/phone.dart
+++ b/lib/items/phone.dart
@@ -1,0 +1,25 @@
+import 'package:contacts_service/contacts_service.dart';
+
+import 'item.dart';
+
+class PhoneItem extends MultaccItem {
+  String phone;
+
+  PhoneItem.fromJson(Map<String, dynamic> json) : phone = json['no'];
+
+  PhoneItem.fromItem(Item item) : phone = item.toString();
+
+  Map<String, dynamic> toJson() => {'no': phone};
+
+  String getHumanReadableType() => 'Phone';
+
+  String getHumanReadableValue() => phone; // @ todo Format phone numbers
+
+  MultaccItemType getType() => MultaccItemType.Phone;
+
+  void launchApp() {
+    // @todo Implement phone launching
+  }
+
+  bool isLaunchable() => true;
+}

--- a/lib/items/twitter.dart
+++ b/lib/items/twitter.dart
@@ -5,14 +5,10 @@ class TwitterItem extends MultaccItem {
   String userId;
 
   TwitterItem.fromJson(Map<String, dynamic> json)
-    : username = json['at'],
-      userId = json['id'];
+      : username = json['at'],
+        userId = json['id'];
 
-  Map<String, dynamic> toJson() =>
-    {
-      'at': username,
-      'id': userId
-    };
+  Map<String, dynamic> toJson() => {'at': username, 'id': userId};
 
   String getHumanReadableType() => 'Twitter';
 

--- a/lib/pages/contacts/contact_model.dart
+++ b/lib/pages/contacts/contact_model.dart
@@ -1,5 +1,7 @@
 import 'package:contacts_service/contacts_service.dart';
 import 'package:multacc/items/item.dart';
+import 'package:multacc/items/phone.dart';
+import 'package:multacc/items/email.dart';
 
 class MultaccContact extends Contact {
   bool isSelected;
@@ -26,14 +28,19 @@ class MultaccContact extends Contact {
     this.postalAddresses = baseContact.postalAddresses;
     this.prefix = baseContact.prefix;
     this.suffix = baseContact.suffix;
-    // @todo Figure out how to store Multacc key in Contact
     // @todo Get IM, notes, etc. from base contact
 
     // Multacc additional contact data
-    this.clientKey = null; // Key in client-side database
-    this.serverKey = null; // Key in server-side database
-    // @todo Pull multacc items from database when loading a contact
-    this.multaccItems = []; // Multacc extension items
+    // @todo Use a field other than identifier for clientKey (#26)
+    clientKey = identifier; // Key in client-side database
+    serverKey = null; // Key in server-side database
+    multaccItems = [
+      ...phones.map((item) => PhoneItem.fromItem(item)), // create PhoneItems from phone Items
+      ...emails.map((item) => EmailItem.fromItem(item)), // create EmailItems from email Items
+      // @todo Convert addresses to Multacc items
+      // @todo Convert IM to Multacc items
+      // @todo Convert SIP to Multacc items
+      // @todo Pull multacc items from database when loading a contact
+    ];
   }
 }
-

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: multiple accounts
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.3.0 <3.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
Closes #27.
* MultaccContact now copies identifier to clientKey (see #14)
* Adds Phone and Email types to the MultaccItemType enum
* Adds EmailItem and PhoneItem classes
    * fromItem constructors convert Item objects from contacts_service
      to these MultaccItem implementations
* Populates multaccItems with PhoneItem and EmailItem instances when
  constructing a MultaccContact from a Contact
* Adds TODOs to do the same for addresses, SIP, and IM
* Increase Dart version to 2.3.0 to enable spread operator
* Whitespace changes in twitter.dart thanks to Android Studio