### PR TITLE
Add support for skipping sign in

### DIFF
--- a/lib/common/bottom_bar.dart
+++ b/lib/common/bottom_bar.dart
@@ -79,9 +79,12 @@ class MultaccBottomBarState extends State<MultaccBottomBar> {
               Theme(
                 data: Theme.of(context).copyWith(accentColor: Colors.white),
                 child: ExpansionTile(
-                  leading: CircleAvatar(backgroundImage: NetworkImage(widget._user.photoUrl)),
-                  title: Text(widget._user.displayName),
-                  subtitle: Text(widget._user.email),
+                  leading: widget._user?.photoUrl != null
+                      ? CircleAvatar(backgroundImage: NetworkImage(widget._user.photoUrl))
+                      : CircleAvatar(child: Icon(Icons.person), foregroundColor: kBackgroundColorLight),
+                  title: Text(widget._user?.displayName ?? 'Anonymous'),
+                  subtitle: Text(widget._user?.email ?? 'You are not signed in',
+                      style: kTinyTextStyle.copyWith(fontStyle: FontStyle.italic)),
                   children: [
                     _buildGroupmeTile(context),
                     ListTile(
@@ -90,7 +93,7 @@ class MultaccBottomBarState extends State<MultaccBottomBar> {
                     ),
                     ListTile(
                       leading: Icon(Icons.power_settings_new),
-                      title: Text('Sign out'),
+                      title: Text(!widget._user.isAnonymous ? 'Sign out' : 'Sign in'),
                       onTap: () async {
                         await _auth.signOut();
                         Navigator.pop(context);

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -98,6 +98,11 @@ class _HomePageState extends State<HomePage> with SingleTickerProviderStateMixin
               ),
               onPressed: _signinWithGoogle,
             ),
+            FlatButton(
+              child: Text('Skip', style: kBodyTextStyle),
+              onPressed: _auth.signInAnonymously,
+              padding: EdgeInsets.all(8.0),
+            ),
           ],
         ),
       ),


### PR DESCRIPTION
- Uses `signInAnonymously` to skip the initial sign-in completely
- Still able to sign in later from the bottom nav menu