### PR TITLE
Add Auth class to wrap FirebaseAuth, allowing google sign in from anywhere in app

### DIFF
--- a/lib/common/auth.dart
+++ b/lib/common/auth.dart
@@ -3,12 +3,10 @@ import 'package:google_sign_in/google_sign_in.dart';
 
 class Auth {
   Auth._();
+  static final Auth instance = Auth._();
 
   FirebaseAuth _firebaseAuth = FirebaseAuth.instance;
   GoogleSignIn _googleSignIn = GoogleSignIn(scopes: <String>['email']);
-
-  static final Auth instance = Auth._();
-  static final FirebaseAuth firebaseAuth = FirebaseAuth.instance;
 
   Stream<FirebaseUser> get onAuthStateChanged => _firebaseAuth.onAuthStateChanged;
 

--- a/lib/common/auth.dart
+++ b/lib/common/auth.dart
@@ -1,0 +1,45 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:google_sign_in/google_sign_in.dart';
+
+class Auth {
+  Auth._();
+
+  FirebaseAuth _firebaseAuth = FirebaseAuth.instance;
+  GoogleSignIn _googleSignIn = GoogleSignIn(scopes: <String>['email']);
+
+  static final Auth instance = Auth._();
+  static final FirebaseAuth firebaseAuth = FirebaseAuth.instance;
+
+  Stream<FirebaseUser> get onAuthStateChanged => _firebaseAuth.onAuthStateChanged;
+
+  Future<AuthResult> signInAnonymously() => _firebaseAuth.signInAnonymously();
+
+  Future<AuthCredential> getGoogleSignInCredential() async {
+    final googleUser = await _googleSignIn.signIn();
+    final googleAuth = await googleUser.authentication;
+    return GoogleAuthProvider.getCredential(
+      accessToken: googleAuth.accessToken,
+      idToken: googleAuth.idToken,
+    );
+  }
+
+  Future<AuthResult> signinWithGoogle() async {
+    final credential = await getGoogleSignInCredential();
+    return _firebaseAuth.signInWithCredential(credential);
+  }
+
+  Future<AuthResult> linkWithGoogleSignIn() async {
+    final credential = await getGoogleSignInCredential();
+    final user = await _firebaseAuth.currentUser();
+    try {
+      final result = await user.linkWithCredential(credential);
+      return result;
+    } catch (ex) {
+      // Exception is thrown when credential is already linked, so delete this anonymous user
+      await user.delete();
+      return _firebaseAuth.signInWithCredential(credential);
+    }
+  }
+
+  Future<void> signOut() => _firebaseAuth.signOut();
+}

--- a/lib/common/bottom_bar.dart
+++ b/lib/common/bottom_bar.dart
@@ -4,15 +4,17 @@ import 'package:flutter_brand_icons/flutter_brand_icons.dart';
 import 'package:flutter_statusbarcolor/flutter_statusbarcolor.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:get_it/get_it.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import 'package:multacc/common/auth.dart';
 import 'package:multacc/common/theme.dart';
 import 'package:multacc/common/constants.dart';
 import 'package:multacc/common/search_delegate.dart';
 import 'package:multacc/pages/home_page.dart';
 import 'package:multacc/pages/settings/settings_page.dart';
-import 'package:shared_preferences/shared_preferences.dart';
-import 'package:url_launcher/url_launcher.dart';
 
-FirebaseAuth _auth = FirebaseAuth.instance;
+Auth _auth = Auth.instance;
 
 /// MultaccBottomBar class containing the logic for FAB, account auth, etc
 class MultaccBottomBar extends StatefulWidget {
@@ -95,7 +97,7 @@ class MultaccBottomBarState extends State<MultaccBottomBar> {
                       leading: Icon(Icons.power_settings_new),
                       title: Text(!widget._user.isAnonymous ? 'Sign out' : 'Sign in'),
                       onTap: () async {
-                        await _auth.signOut();
+                        widget._user.isAnonymous ? await _auth.linkWithGoogleSignIn() : await _auth.signOut();
                         Navigator.pop(context);
                       },
                     ),

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -5,7 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_brand_icons/flutter_brand_icons.dart';
 import 'package:get_it/get_it.dart';
 import 'package:google_fonts/google_fonts.dart';
-import 'package:google_sign_in/google_sign_in.dart';
+import 'package:multacc/common/auth.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:multacc/common/bottom_bar.dart';
@@ -14,8 +14,7 @@ import 'package:multacc/pages/chats/chats_page.dart';
 import 'package:multacc/pages/contacts/contacts_page.dart';
 import 'package:multacc/pages/profile/profile_page.dart';
 
-FirebaseAuth _auth = FirebaseAuth.instance;
-GoogleSignIn _googleSignIn = GoogleSignIn(scopes: <String>['email']);
+Auth _auth = Auth.instance;
 
 final globalScaffoldKey = GlobalKey<ScaffoldState>();
 
@@ -96,7 +95,7 @@ class _HomePageState extends State<HomePage> with SingleTickerProviderStateMixin
                   Text('Sign in with Google', style: kHeaderTextStyle),
                 ],
               ),
-              onPressed: _signinWithGoogle,
+              onPressed: _auth.signinWithGoogle,
             ),
             FlatButton(
               child: Text('Skip', style: kBodyTextStyle),
@@ -109,15 +108,7 @@ class _HomePageState extends State<HomePage> with SingleTickerProviderStateMixin
     );
   }
 
-  void _signinWithGoogle() async {
-    final googleUser = await _googleSignIn.signIn();
-    final googleAuth = await googleUser.authentication;
-    final credential = GoogleAuthProvider.getCredential(
-      accessToken: googleAuth.accessToken,
-      idToken: googleAuth.idToken,
-    );
-    await _auth.signInWithCredential(credential);
-  }
+  
 
   Scaffold _buildHomePageBody(BuildContext context, FirebaseUser user) {
     return Scaffold(


### PR DESCRIPTION
- Signing in with google when already signed in anonymously will now link the credentials instead of making a new user
- If the google account was already used to sign in previously, then the anonymous user will be deleted