### PR TITLE
remove "convention" for constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ A flutter app that integrates communication platforms and lets you consolidate a
 
 ## conventions
 - Tab width = 2 spaces
-- All constants either use SCREAMING_CAPS or start with k
 - Line length is 120
 - Single quotes for strings
 - Dart/Prettier automatically formats the code if there are proper trailing commas


### PR DESCRIPTION
since it is unconventional

https://dart.dev/guides/language/effective-dart/style#prefer-using-lowercamelcase-for-constant-names
https://dart.dev/guides/language/effective-dart/style#dont-use-prefix-letters