### PR TITLE
Generate display name for contacts without one

### DIFF
--- a/lib/common/search_delegate.dart
+++ b/lib/common/search_delegate.dart
@@ -45,8 +45,9 @@ class BottomBarSearchDelegate extends SearchDelegate<String> {
   @override
   Widget buildResults(BuildContext context) {
     final results = query != ''
-        ? contactsData.allContacts.where((e) => e.displayName.toLowerCase().contains(query.toLowerCase())).toList()
+        ? contactsData.allContacts.where((e) => e.name.toLowerCase().contains(query.toLowerCase())).toList()
         : []; // don't show the whole damn list if search query is empty
+    // @todo use a better search algorithm
 
     return ListView.builder(
       padding: EdgeInsets.all(8.0),
@@ -56,7 +57,7 @@ class BottomBarSearchDelegate extends SearchDelegate<String> {
         return ListTile(
           contentPadding: EdgeInsets.all(8.0),
           leading: Avatars.buildContactAvatar(memoryImage: contact.avatar),
-          title: Text(results[index].displayName),
+          title: Text(contact.name),
           onTap: () => Navigator.of(context).push(MaterialPageRoute(
             builder: (context) => Scaffold(
               appBar: AppBar(), // for back button

--- a/lib/pages/contacts/contact_details_page.dart
+++ b/lib/pages/contacts/contact_details_page.dart
@@ -94,7 +94,7 @@ class _ContactDetailsPageState extends State<ContactDetailsPage> {
   Padding _buildName() {
     return Padding(
       padding: const EdgeInsets.all(16.0),
-      child: Text(contact.displayName, style: kHeaderTextStyle),
+      child: Text(contact.name, style: kHeaderTextStyle),
     );
   }
 

--- a/lib/pages/contacts/contact_model.dart
+++ b/lib/pages/contacts/contact_model.dart
@@ -56,6 +56,7 @@ class MultaccContact extends Contact {
     this.suffix = baseContact.suffix;
     // @todo Get IM, notes, etc. from base contact
 
+
     // Multacc additional contact data
     // @todo Use a field other than identifier for clientKey (#26)
     clientKey = identifier; // Key in client-side database
@@ -67,6 +68,22 @@ class MultaccContact extends Contact {
       // @todo Convert IM to Multacc items
       // @todo Convert SIP to Multacc items
     ];
+  }
+
+  // Get display name for contact
+  String get name {
+    if (displayName == null || displayName.trim() == '') {
+      displayName = [prefix, givenName, middleName, familyName, suffix].join(' ');
+    }
+    if (displayName != null && displayName.trim() != '') {
+      return displayName;
+    }
+    for (MultaccItem item in multaccItems) {
+      if (item.humanReadableValue != '') {
+        return item.humanReadableValue;
+      }
+    }
+    return 'Contact';
   }
 
   // Returns true if the base contact fields match

--- a/lib/pages/contacts/contact_model.dart
+++ b/lib/pages/contacts/contact_model.dart
@@ -73,7 +73,7 @@ class MultaccContact extends Contact {
   // Get display name for contact
   String get name {
     if (displayName == null || displayName.trim() == '') {
-      displayName = [prefix, givenName, middleName, familyName, suffix].join(' ');
+      displayName = [prefix, givenName, middleName, familyName, suffix].where((x) => x != null).join(' ');
     }
     if (displayName != null && displayName.trim() != '') {
       return displayName;

--- a/lib/pages/contacts/contacts_page.dart
+++ b/lib/pages/contacts/contacts_page.dart
@@ -29,7 +29,7 @@ class _ContactsPageState extends State<ContactsPage> with WidgetsBindingObserver
   Widget build(BuildContext context) {
     return Observer(
       builder: (_) {
-        contactsData.allContacts.sort((a, b) => a.displayName.compareTo(b.displayName));
+        contactsData.allContacts.sort((a, b) => a.name.compareTo(b.name));
         return ListTileTheme(
           selectedColor: kPrimaryColor,
           child: LiquidPullToRefresh(
@@ -54,7 +54,7 @@ class _ContactsPageState extends State<ContactsPage> with WidgetsBindingObserver
     return ListTile(
       contentPadding: EdgeInsets.all(6.0),
       leading: Avatars.buildContactAvatar(memoryImage: contact.avatar),
-      title: Padding(padding: EdgeInsets.only(left: 8.0), child: Text(contact.displayName, style: kBodyTextStyle)),
+      title: Padding(padding: EdgeInsets.only(left: 8.0), child: Text(contact.name, style: kBodyTextStyle)),
       onTap: () => _onContactPressed(index),
       onLongPress: () => _onLongPress(index),
       selected: _isSelected(index),


### PR DESCRIPTION
Closes #135.

This adds a name getter on MultaccContact that should be read instead of
displayName. If displayName is set, its value is returned. Otherwise, it
attempts to use the other name fields. If none of these contain a name,
it returns the human-readable value of the first item with one. If no
items have a human-readable value, it falls back to the text 'Contact'.

Will have to update David's code as well