### PR TITLE
Refactor contact input fields and base item conversion

### DIFF
--- a/lib/items/email.dart
+++ b/lib/items/email.dart
@@ -16,6 +16,8 @@ class EmailItem extends MultaccItem {
     : email = item.value,
       label = item.label;
 
+  Item toItem() => Item(label: label, value: email);
+
   toMap() => {'email': email, 'label': label};
 
   get humanReadableValue => email ?? '';

--- a/lib/items/phone.dart
+++ b/lib/items/phone.dart
@@ -21,6 +21,8 @@ class PhoneItem extends MultaccItem {
       : phone = item.value,
         label = item.label;
 
+  Item toItem() => Item(label: label, value: phone);
+
   toMap() => {'no': phone, 'label': label};
 
   get humanReadableValue => phone ?? ''; // @todo Format phone numbers

--- a/lib/items/text.dart
+++ b/lib/items/text.dart
@@ -1,5 +1,3 @@
-import 'package:contacts_service/contacts_service.dart';
-import 'package:url_launcher/url_launcher.dart';
 import 'item.dart';
 
 class TextItem extends MultaccItem {

--- a/lib/items/url.dart
+++ b/lib/items/url.dart
@@ -1,4 +1,3 @@
-import 'package:contacts_service/contacts_service.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'item.dart';
 

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -200,13 +200,12 @@ class _HomePageState extends State<HomePage> with SingleTickerProviderStateMixin
 }
 
 class _MultaccTab extends StatefulWidget {
-  Text titleText;
-  bool isExpanded;
+  final Text titleText;
+  final bool isExpanded;
 
-  _MultaccTab(String title, bool isExpanded) {
-    titleText = Text(title, style: kHeaderTextStyle);
-    this.isExpanded = isExpanded;
-  }
+  _MultaccTab(String title, bool isExpanded)
+      : titleText = Text(title, style: kHeaderTextStyle),
+        this.isExpanded = isExpanded;
 
   _MultaccTabState createState() => _MultaccTabState();
 }


### PR DESCRIPTION
* Refactor input field logic in contact form page (closes #172)
* Add textbox to specify item value only if type is inputtable
* Move base Item conversion logic to PhoneItem/EmailItem

Plus some minor cleanup to shut up Dart Analysis:
* Remove unused imports from TextItem and UrlItem
* Make fields of _MultaccTab final since widgets are immutable