### PR TITLE
Add facebook, instagram, twitter and snapchat items

### DIFF
--- a/lib/items/facebook.dart
+++ b/lib/items/facebook.dart
@@ -81,15 +81,13 @@ class FacebookItem extends MultaccItem {
         _fetchId();
       }
     }
-    } else {
-      username = input.trim();
-    }
   }
  
  void _fetchUsername() {
    // @todo Fetch Facebook username from id
  }
  
+  // @todo More robust Facebook id fetching
   void _fetchId() async {
     final response = parse((await http.Client().get('https://facebook.com/$username')).body);
     final meta = response.head.getElementsByTagName('meta').firstWhere((meta) => meta.attributes['property'] == 'al:android:url');

--- a/lib/items/facebook.dart
+++ b/lib/items/facebook.dart
@@ -29,10 +29,14 @@ class FacebookItem extends MultaccItem {
   get type => MultaccItemType.Facebook;
 
   launchApp() async {
-    try {
-      await launch('fb://profile/$userId');
-    } catch (ex) {
-      launch('https://facebook.com/$_validUsernameOrId');
+    if ((userId ?? '') != '') {
+      try {
+        await launch('fb://profile/$userId');
+      } catch (e) {
+        launch('https://facebook.com/$userId');
+      }
+    } else {
+      launch('https://facebook.com/$username');
     }
   }
 
@@ -81,6 +85,10 @@ class FacebookItem extends MultaccItem {
       username = input.trim();
     }
   }
+ 
+ void _fetchUsername() {
+   // @todo Fetch Facebook username from id
+ }
  
   void _fetchId() async {
     final response = parse((await http.Client().get('https://facebook.com/$username')).body);

--- a/lib/items/facebook.dart
+++ b/lib/items/facebook.dart
@@ -5,20 +5,26 @@ import 'package:html/parser.dart' show parse;
 import 'item.dart';
 
 class FacebookItem extends MultaccItem {
-  String username;
   String userId;
+
+  String _username;
+  get username => _username ?? '';
+  set username(String input) {
+    _username = input;
+    _fetchId();
+  }
 
   FacebookItem();
 
   FacebookItem.fromJson(Map<String, dynamic> json)
-      : username = json['username'],
+      : _username = json['username'],
         userId = json['id'];
 
   toMap() => {'username': username, 'id': userId};
 
-  get humanReadableValue => (username ?? '') != '' ? username : (userId != null ? 'fb.com/$userId' : '');
+  get humanReadableValue => username != '' ? username : (userId != null ? 'fb.com/$userId' : '');
 
-  get _validUsernameOrId => (username ?? '') == '' ? userId : username;
+  get _validUsernameOrId => username != '' ? username : userId;
 
   get type => MultaccItemType.Facebook;
 
@@ -47,15 +53,14 @@ class FacebookItem extends MultaccItem {
       username = url.pathSegments.last;
     } else if (url.path.contains('profile.php')) {
       userId = url.queryParameters['id'];
+      _username = '';
     } else if (url.host.contains('facebook.com') || url.host.contains('fb.com')) {
       username = url.pathSegments.last;
     } else {
       username = input.trim();
     }
-
-    if (userId == null) _fetchId();
   }
-
+ 
   void _fetchId() async {
     final response = parse((await http.Client().get('https://facebook.com/$username')).body);
     final meta = response.head.getElementsByTagName('meta').firstWhere((meta) => meta.attributes['property'] == 'al:android:url');

--- a/lib/items/facebook.dart
+++ b/lib/items/facebook.dart
@@ -46,15 +46,17 @@ class FacebookItem extends MultaccItem {
 
   get isLaunchable => true;
 
+  // @todo Add 'value' getter for editing
   set value(String input) {
     Uri url = Uri.parse(input);
+    String urlText = url.toString().toLowerCase();
 
-    if (url.host.contains('fb.me') || url.host.contains('m.me')) {
+    if (urlText.contains('fb.me') || urlText.contains('m.me')) {
       username = url.pathSegments.last;
-    } else if (url.path.contains('profile.php')) {
+    } else if (urlText.contains('profile.php')) {
       userId = url.queryParameters['id'];
       _username = '';
-    } else if (url.host.contains('facebook.com') || url.host.contains('fb.com')) {
+    } else if (urlText.contains('facebook.com') || urlText.contains('fb.com')) {
       username = url.pathSegments.last;
     } else {
       username = input.trim();

--- a/lib/items/facebook.dart
+++ b/lib/items/facebook.dart
@@ -4,23 +4,49 @@ import 'item.dart';
 
 class FacebookItem extends MultaccItem {
   String url;
+  String pageName;
 
   FacebookItem();
 
   FacebookItem.fromJson(Map<String, dynamic> json)
-      : url = json['url'];
+      : url = json['url'],
+        pageName = json['page'];
 
-  toMap() => {'url': url};
+  toMap() => {'url': url, 'page': pageName};
 
-  get humanReadableValue => url;
+  get humanReadableValue => 'fb/$pageName';
 
   get type => MultaccItemType.Facebook;
 
-  launchApp() => launch(url);
+  launchApp() async {
+    try {
+      await launch('fb://profile/$pageName');
+    } catch (ex) {
+      launch(url);
+    }
+  }
+
+  launchMessenger() async {
+    try {
+      await launch('fb-messenger://user/$pageName');
+    } catch (ex) {
+      launch('https://facebook.com/messages/t/$pageName');
+    }
+  }
 
   get isLaunchable => true;
 
   set value(String input) {
     url = input;
+    input = input.toLowerCase();
+    if (input.contains('fb.me') || input.contains('m.me')) {
+      pageName = input.split('me/')[1];
+    } else if (input.contains('profile.php?id=')) {
+      pageName = input.split('id=')[1];
+    } else if (input.contains('facebook.com/')) {
+      pageName = input.split('.com/')[1];
+    } else {
+      pageName = input;
+    }
   }
 }

--- a/lib/items/facebook.dart
+++ b/lib/items/facebook.dart
@@ -1,52 +1,62 @@
 import 'package:url_launcher/url_launcher.dart';
+import 'package:http/http.dart' as http;
+import 'package:html/parser.dart' show parse;
 
 import 'item.dart';
 
 class FacebookItem extends MultaccItem {
-  String url;
-  String pageName;
+  String username;
+  String userId;
 
   FacebookItem();
 
   FacebookItem.fromJson(Map<String, dynamic> json)
-      : url = json['url'],
-        pageName = json['page'];
+      : username = json['username'],
+        userId = json['id'];
 
-  toMap() => {'url': url, 'page': pageName};
+  toMap() => {'username': username, 'userId': userId};
 
-  get humanReadableValue => 'fb/$pageName';
+  get humanReadableValue => username ?? (userId != null ? 'fb.com/$userId' : '');
 
   get type => MultaccItemType.Facebook;
 
   launchApp() async {
     try {
-      await launch('fb://profile/$pageName');
+      await launch('fb://profile/$userId');
     } catch (ex) {
-      launch(url);
+      launch('https://facebook.com/${username ?? userId}');
     }
   }
 
   launchMessenger() async {
     try {
-      await launch('fb-messenger://user/$pageName');
+      await launch('fb-messenger://user/${username ?? userId}');
     } catch (ex) {
-      launch('https://facebook.com/messages/t/$pageName');
+      launch('https://facebook.com/messages/t/${username ?? userId}');
     }
   }
 
   get isLaunchable => true;
 
   set value(String input) {
-    url = input;
-    input = input.toLowerCase();
-    if (input.contains('fb.me') || input.contains('m.me')) {
-      pageName = input.split('me/')[1];
+    String domain = input.toLowerCase().split('/')[0];
+
+    if (domain.contains('fb.me') || domain.contains('m.me')) {
+      username = input.split('/').last;
     } else if (input.contains('profile.php?id=')) {
-      pageName = input.split('id=')[1];
-    } else if (input.contains('facebook.com/')) {
-      pageName = input.split('.com/')[1];
+      userId = input.split('id=')[1];
+    } else if (domain.contains('facebook.com') || domain.contains('fb.com')) {
+      username = input.split('/').last;
     } else {
-      pageName = input;
+      username = input;
     }
+
+    if (userId == null) _fetchId();
+  }
+
+  void _fetchId() async {
+    final response = parse((await http.Client().get('https://facebook.com/$username')).body);
+    final meta = response.head.getElementsByTagName('meta').firstWhere((meta) => meta.attributes['property'] == 'al:android:url');
+    userId = meta.attributes['content'].split('/').last;
   }
 }

--- a/lib/items/facebook.dart
+++ b/lib/items/facebook.dart
@@ -1,0 +1,26 @@
+import 'package:url_launcher/url_launcher.dart';
+
+import 'item.dart';
+
+class FacebookItem extends MultaccItem {
+  String url;
+
+  FacebookItem();
+
+  FacebookItem.fromJson(Map<String, dynamic> json)
+      : url = json['url'];
+
+  toMap() => {'url': url};
+
+  get humanReadableValue => url;
+
+  get type => MultaccItemType.Facebook;
+
+  launchApp() => launch(url);
+
+  get isLaunchable => true;
+
+  set value(String input) {
+    url = input;
+  }
+}

--- a/lib/items/instagram.dart
+++ b/lib/items/instagram.dart
@@ -12,10 +12,10 @@ class InstagramItem extends MultaccItem {
   InstagramItem();
 
   InstagramItem.fromJson(Map<String, dynamic> json)
-      : username = json['at'],
+      : username = json['username'],
         userId = json['id'];
 
-  toMap() => {'at': username, 'id': userId};
+  toMap() => {'username': username, 'id': userId};
 
   get humanReadableValue => '@${username ?? ''}';
 
@@ -42,7 +42,7 @@ class InstagramItem extends MultaccItem {
   get isLaunchable => true;
 
   set value(String input) {
-    username = input.substring(input.startsWith('@') ? 1 : 0).trim();
+    username = input.trim().substring(input.startsWith('@') ? 1 : 0);
     _fetchId();
   }
 

--- a/lib/items/instagram.dart
+++ b/lib/items/instagram.dart
@@ -17,7 +17,7 @@ class InstagramItem extends MultaccItem {
 
   toMap() => {'at': username, 'id': userId};
 
-  get humanReadableValue => (username == null || username.trim() == '') ? '' : '@$username';
+  get humanReadableValue => '@${username ?? ''}';
 
   get type => MultaccItemType.Instagram;
 
@@ -42,11 +42,11 @@ class InstagramItem extends MultaccItem {
   get isLaunchable => true;
 
   set value(String input) {
-    username = input.substring(input.startsWith('@') ? 1 : 0);
-    _fetchInstagramId(username);
+    username = input.substring(input.startsWith('@') ? 1 : 0).trim();
+    _fetchId();
   }
 
-  void _fetchInstagramId(username) async {
+  void _fetchId() async {
     String searchUrl = 'https://www.instagram.com/web/search/topsearch/?context=user&count=0&query=';
     final response = jsonDecode((await http.Client().get('$searchUrl$username')).body);
     userId = response['users'][0]['user']['pk'];

--- a/lib/items/instagram.dart
+++ b/lib/items/instagram.dart
@@ -1,4 +1,7 @@
+import 'dart:convert';
+
 import 'package:url_launcher/url_launcher.dart';
+import 'package:http/http.dart' as http;
 
 import 'item.dart';
 
@@ -18,12 +21,34 @@ class InstagramItem extends MultaccItem {
 
   get type => MultaccItemType.Instagram;
 
-  launchApp() => launch('https://www.instagram.com/$username');
+  launchApp() async {
+    try {
+      await launch('instagram://user?username=$username');
+    } catch (ex) {
+      launch('https://instagram.com/$username');
+    }
+  }
+
+  launchDirectMessage() async {
+    try {
+      // @todo Figure out how to get Instagram DM thread id and launch DM
+      // await launch('instagram://direct?username=$username');
+      launch('https://instagram.com/direct/inbox');
+    } catch (ex) {
+      launchApp();
+    }
+  }
 
   get isLaunchable => true;
 
   set value(String input) {
     username = input.substring(input.startsWith('@') ? 1 : 0);
-    // @todo Detect Instagram ID from username
+    _fetchInstagramId(username);
+  }
+
+  void _fetchInstagramId(username) async {
+    String searchUrl = 'https://www.instagram.com/web/search/topsearch/?context=user&count=0&query=';
+    final response = jsonDecode((await http.Client().get('$searchUrl$username')).body);
+    userId = response['users'][0]['user']['pk'];
   }
 }

--- a/lib/items/instagram.dart
+++ b/lib/items/instagram.dart
@@ -42,7 +42,7 @@ class InstagramItem extends MultaccItem {
   get isLaunchable => true;
 
   set value(String input) {
-    username = input.trim().substring(input.startsWith('@') ? 1 : 0);
+    username = input.trim().substring(input.trim().startsWith('@') ? 1 : 0);
     _fetchId();
   }
 

--- a/lib/items/instagram.dart
+++ b/lib/items/instagram.dart
@@ -1,0 +1,29 @@
+import 'package:url_launcher/url_launcher.dart';
+
+import 'item.dart';
+
+class InstagramItem extends MultaccItem {
+  String username;
+  String userId;
+
+  InstagramItem();
+
+  InstagramItem.fromJson(Map<String, dynamic> json)
+      : username = json['at'],
+        userId = json['id'];
+
+  toMap() => {'at': username, 'id': userId};
+
+  get humanReadableValue => (username == null || username.trim() == '') ? '' : '@$username';
+
+  get type => MultaccItemType.Instagram;
+
+  launchApp() => launch('https://www.instagram.com/$username');
+
+  get isLaunchable => true;
+
+  set value(String input) {
+    username = input.substring(input.startsWith('@') ? 1 : 0);
+    // @todo Detect Instagram ID from username
+  }
+}

--- a/lib/items/item.dart
+++ b/lib/items/item.dart
@@ -5,6 +5,7 @@ import 'package:flutter_icons/flutter_icons.dart';
 import 'package:hive/hive.dart';
 import 'package:multacc/database/type_ids.dart';
 import 'package:enum_to_string/enum_to_string.dart';
+import 'package:multacc/items/snapchat.dart';
 
 import 'twitter.dart';
 import 'email.dart';
@@ -37,7 +38,7 @@ abstract class MultaccItem {
         item = EmailItem.fromJson(json);
         break;
       case MultaccItemType.Snapchat:
-//        item = SnapchatItem.fromJson(json);
+        item = SnapchatItem.fromJson(json);
         break;
       case MultaccItemType.Instagram:
 //        item = InstagramItem.fromJson(json);
@@ -122,6 +123,8 @@ extension MultaccItemTypeInfo on MultaccItemType {
     switch (this) {
       case MultaccItemType.Twitter:
         return Icon(MaterialCommunityIcons.twitter);
+      case MultaccItemType.Snapchat:
+        return Icon(MaterialCommunityIcons.snapchat);
       case MultaccItemType.Phone:
         return Icon(Icons.phone);
       case MultaccItemType.Email:
@@ -173,6 +176,8 @@ extension MultaccItemTypeInfo on MultaccItemType {
     switch (this) {
       case MultaccItemType.Twitter:
         return TwitterItem();
+      case MultaccItemType.Snapchat:
+        return SnapchatItem();
       case MultaccItemType.Phone:
         return PhoneItem();
       case MultaccItemType.Email:
@@ -180,9 +185,8 @@ extension MultaccItemTypeInfo on MultaccItemType {
       case MultaccItemType.URL:
         return URLItem();
       case MultaccItemType.Text:
-        return TextItem();
       default:
-        return null;
+        return TextItem();
     }
   }
 }

--- a/lib/items/item.dart
+++ b/lib/items/item.dart
@@ -186,6 +186,8 @@ extension MultaccItemTypeInfo on MultaccItemType {
         return SnapchatItem();
       case MultaccItemType.Instagram:
         return InstagramItem();
+      case MultaccItemType.Facebook:
+        return FacebookItem();
       case MultaccItemType.Phone:
         return PhoneItem();
       case MultaccItemType.Email:

--- a/lib/items/item.dart
+++ b/lib/items/item.dart
@@ -3,15 +3,17 @@ import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:flutter_icons/flutter_icons.dart';
 import 'package:hive/hive.dart';
-import 'package:multacc/database/type_ids.dart';
 import 'package:enum_to_string/enum_to_string.dart';
-import 'package:multacc/items/snapchat.dart';
 
-import 'twitter.dart';
-import 'email.dart';
-import 'phone.dart';
-import 'url.dart';
-import 'text.dart';
+import 'package:multacc/database/type_ids.dart';
+import 'package:multacc/items/facebook.dart';
+import 'package:multacc/items/twitter.dart';
+import 'package:multacc/items/email.dart';
+import 'package:multacc/items/phone.dart';
+import 'package:multacc/items/url.dart';
+import 'package:multacc/items/text.dart';
+import 'package:multacc/items/instagram.dart';
+import 'package:multacc/items/snapchat.dart';
 
 const ITEM_TYPE_KEY = '_t';
 const ITEM_KEY_KEY = '_id';
@@ -41,10 +43,10 @@ abstract class MultaccItem {
         item = SnapchatItem.fromJson(json);
         break;
       case MultaccItemType.Instagram:
-//        item = InstagramItem.fromJson(json);
+        item = InstagramItem.fromJson(json);
         break;
       case MultaccItemType.Facebook:
-//        item = FacebookItem.fromJson(json);
+        item = FacebookItem.fromJson(json);
         break;
       case MultaccItemType.Discord:
 //        item = DiscordItem.fromJson(json);
@@ -106,9 +108,9 @@ abstract class MultaccItem {
 
 enum MultaccItemType {
   Twitter,
-  Snapchat, // @todo Implement snapchat
-  Instagram, // @todo Implement instagram
-  Facebook, // @todo Implement facebook
+  Snapchat,
+  Instagram,
+  Facebook,
   Discord, // @todo Implement discord
   Dogecoin, // @todo Implement dogecoin
   Phone,
@@ -125,6 +127,10 @@ extension MultaccItemTypeInfo on MultaccItemType {
         return Icon(MaterialCommunityIcons.twitter);
       case MultaccItemType.Snapchat:
         return Icon(MaterialCommunityIcons.snapchat);
+      case MultaccItemType.Instagram:
+        return Icon(MaterialCommunityIcons.instagram);
+      case MultaccItemType.Facebook:
+        return Icon(MaterialCommunityIcons.facebook);
       case MultaccItemType.Phone:
         return Icon(Icons.phone);
       case MultaccItemType.Email:
@@ -178,6 +184,8 @@ extension MultaccItemTypeInfo on MultaccItemType {
         return TwitterItem();
       case MultaccItemType.Snapchat:
         return SnapchatItem();
+      case MultaccItemType.Instagram:
+        return InstagramItem();
       case MultaccItemType.Phone:
         return PhoneItem();
       case MultaccItemType.Email:

--- a/lib/items/snapchat.dart
+++ b/lib/items/snapchat.dart
@@ -11,7 +11,7 @@ class SnapchatItem extends MultaccItem {
 
   toMap() => {'username': username};
 
-  get humanReadableValue => '@${username ?? ''}';
+  get humanReadableValue => username ?? '';
 
   get type => MultaccItemType.Snapchat;
 
@@ -20,6 +20,6 @@ class SnapchatItem extends MultaccItem {
   get isLaunchable => true;
 
   set value(String input) {
-    username = input.trim().substring(input.startsWith('@') ? 1 : 0);
+    username = input.trim().substring(input.trim().startsWith('@') ? 1 : 0);
   }
 }

--- a/lib/items/snapchat.dart
+++ b/lib/items/snapchat.dart
@@ -7,9 +7,9 @@ class SnapchatItem extends MultaccItem {
 
   SnapchatItem();
 
-  SnapchatItem.fromJson(Map<String, dynamic> json) : username = json['at'];
+  SnapchatItem.fromJson(Map<String, dynamic> json) : username = json['username'];
 
-  toMap() => {'at': username};
+  toMap() => {'username': username};
 
   get humanReadableValue => '@${username ?? ''}';
 
@@ -20,6 +20,6 @@ class SnapchatItem extends MultaccItem {
   get isLaunchable => true;
 
   set value(String input) {
-    username = input.substring(input.startsWith('@') ? 1 : 0).trim();
+    username = input.trim().substring(input.startsWith('@') ? 1 : 0);
   }
 }

--- a/lib/items/snapchat.dart
+++ b/lib/items/snapchat.dart
@@ -1,0 +1,25 @@
+import 'package:url_launcher/url_launcher.dart';
+
+import 'item.dart';
+
+class SnapchatItem extends MultaccItem {
+  String username;
+
+  SnapchatItem();
+
+  SnapchatItem.fromJson(Map<String, dynamic> json) : username = json['at'];
+
+  toMap() => {'at': username};
+
+  get humanReadableValue => (username == null || username.trim() == '') ? '' : '@$username';
+
+  get type => MultaccItemType.Snapchat;
+
+  launchApp() => launch('https://www.snapchat.com/add/$username');
+
+  get isLaunchable => true;
+
+  set value(String input) {
+    username = input.substring(input.startsWith('@') ? 1 : 0);
+  }
+}

--- a/lib/items/snapchat.dart
+++ b/lib/items/snapchat.dart
@@ -11,7 +11,7 @@ class SnapchatItem extends MultaccItem {
 
   toMap() => {'at': username};
 
-  get humanReadableValue => (username == null || username.trim() == '') ? '' : '@$username';
+  get humanReadableValue => '@${username ?? ''}';
 
   get type => MultaccItemType.Snapchat;
 
@@ -20,6 +20,6 @@ class SnapchatItem extends MultaccItem {
   get isLaunchable => true;
 
   set value(String input) {
-    username = input.substring(input.startsWith('@') ? 1 : 0);
+    username = input.substring(input.startsWith('@') ? 1 : 0).trim();
   }
 }

--- a/lib/items/twitter.dart
+++ b/lib/items/twitter.dart
@@ -12,10 +12,10 @@ class TwitterItem extends MultaccItem {
   TwitterItem();
 
   TwitterItem.fromJson(Map<String, dynamic> json)
-      : username = json['at'],
+      : username = json['username'],
         userId = json['id'];
 
-  toMap() => {'at': username, 'id': userId};
+  toMap() => {'username': username, 'id': userId};
 
   get humanReadableValue => '@${username ?? ''}';
 
@@ -32,7 +32,7 @@ class TwitterItem extends MultaccItem {
   get isLaunchable => true;
 
   set value(String input) {
-    username = input.substring(input.startsWith('@') ? 1 : 0).trim();
+    username = input.trim().substring(input.startsWith('@') ? 1 : 0);
     _fetchId();
   }
 

--- a/lib/items/twitter.dart
+++ b/lib/items/twitter.dart
@@ -17,7 +17,7 @@ class TwitterItem extends MultaccItem {
 
   toMap() => {'username': username, 'id': userId};
 
-  get humanReadableValue => '@${username ?? ''}';
+  get humanReadableValue => (username ?? '') == '' ? '' : '@$username';
 
   get type => MultaccItemType.Twitter;
 
@@ -32,7 +32,7 @@ class TwitterItem extends MultaccItem {
   get isLaunchable => true;
 
   set value(String input) {
-    username = input.trim().substring(input.startsWith('@') ? 1 : 0);
+    username = input.trim().substring(input.trim().startsWith('@') ? 1 : 0);
     _fetchId();
   }
 

--- a/lib/pages/contacts/contact_details_page.dart
+++ b/lib/pages/contacts/contact_details_page.dart
@@ -1,7 +1,12 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_icons/flutter_icons.dart';
 import 'package:flutter_statusbarcolor/flutter_statusbarcolor.dart';
+
 import 'package:multacc/common/avatars.dart';
 import 'package:multacc/common/theme.dart';
+import 'package:multacc/items/email.dart';
+import 'package:multacc/items/facebook.dart';
+import 'package:multacc/items/instagram.dart';
 import 'package:multacc/items/item.dart';
 import 'package:multacc/items/phone.dart';
 import 'package:multacc/database/contact_model.dart';
@@ -51,7 +56,7 @@ class _ContactDetailsPageState extends State<ContactDetailsPage> {
           final item = contact.multaccItems.elementAt(index);
           return ListTile(
             title: Text(item.humanReadableValue ?? ''),
-            trailing: Text(item.type == MultaccItemType.Phone ? (item as PhoneItem).label : ''),
+            trailing: _buildTrailing(item),
             leading: item.icon,
             onTap: item.isLaunchable ? item.launchApp : null,
           );
@@ -92,11 +97,32 @@ class _ContactDetailsPageState extends State<ContactDetailsPage> {
     );
   }
 
-  Padding _buildName() {
+  Widget _buildName() {
     return Padding(
       padding: const EdgeInsets.all(16.0),
       child: Text(contact.name, style: kHeaderTextStyle),
     );
+  }
+
+  Widget _buildTrailing(MultaccItem item) {
+    switch (item.type) {
+      case MultaccItemType.Phone:
+        return Text((item as PhoneItem).label);
+      case MultaccItemType.Email:
+        return Text((item as EmailItem).label);
+      case MultaccItemType.Facebook:
+        return IconButton(
+          icon: Icon(MaterialCommunityIcons.facebook_messenger),
+          onPressed: () => (item as FacebookItem).launchMessenger(),
+        );
+      case MultaccItemType.Instagram:
+        return IconButton(
+          icon: Icon(SimpleLineIcons.paper_plane),
+          onPressed: () => (item as InstagramItem).launchDirectMessage(),
+        );
+      default:
+        return Text('');
+    }
   }
 
   @override

--- a/lib/pages/contacts/contact_details_page.dart
+++ b/lib/pages/contacts/contact_details_page.dart
@@ -104,6 +104,7 @@ class _ContactDetailsPageState extends State<ContactDetailsPage> {
     );
   }
 
+  // @todo Refactor trailing button logic
   Widget _buildTrailing(MultaccItem item) {
     switch (item.type) {
       case MultaccItemType.Phone:

--- a/lib/pages/contacts/contact_form_page.dart
+++ b/lib/pages/contacts/contact_form_page.dart
@@ -269,7 +269,11 @@ class _ContactForm extends State<ContactFormPage> {
       children: <Widget>[
         SizedBox(height: 30, child: null),
         InkWell(
-          onTap: () => items.add(type.createItem()),
+          onTap: () {
+            setState(() {
+              items.add(type.createItem());
+            });
+          },
           child: Row(children: rowWidgets),
         ),
       ],

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -44,7 +44,7 @@ class _HomePageState extends State<HomePage> with SingleTickerProviderStateMixin
     super.initState();
     contactsData = GetIt.I.get<ContactsData>();
 
-    userContact = contactsData.allContacts[0];
+    // userContact = contactsData.allContacts[0] ?? null;
 
     initDynamicLinks();
 


### PR DESCRIPTION
- Added more items (as well as fallthrough into TextItem for those yet to be implemented):
  - Instagram item (closes #8)
    - Primitive support for launching ig profile
    - Launching a DM does not work. Need to reverse engineer the deep link and the thread id
  - Facebook item (closes #9)
    - Supports deeplinks to both facebook profile and messenger (and messenger lite)
  - Snapchat item (closes #7)
    - Supports deep linking into "add snapchat user"
    - Can't figure out how to deep link into chat screen yet
- Added twitter ID (closes #12) and twitter launching (closes #128)
- Fixed #182 (breaks Profile page, which is okay because it does not work anyway)
- Fixed missing `setState` which caused add items to stop working