### PR TITLE
Improve contact details page

### DIFF
--- a/lib/pages/contacts/contact_details_page.dart
+++ b/lib/pages/contacts/contact_details_page.dart
@@ -29,24 +29,21 @@ class _ContactDetailsPageState extends State<ContactDetailsPage> {
   Widget build(BuildContext context) {
     FlutterStatusbarcolor.setNavigationBarColor(kBackgroundColor);
 
-    return Material(
-      child: Container(
-        height: MediaQuery.of(context).size.height / 1.2, // @todo Fix ContactDetails height for scrolling
-        child: Column(
-          children: <Widget>[
-            Avatars.buildContactAvatar(memoryImage: contact.avatar, radius: 40.0),
-            _buildName(),
-            // _buildShortcutsRow(),
-            _buildContactItemsList(),
-          ],
-        ),
+    return Container(
+      child: Column(
+        children: <Widget>[
+          Avatars.buildContactAvatar(memoryImage: contact.avatar, radius: 40.0),
+          _buildName(),
+          // _buildShortcutsRow(),
+          _buildContactItemsList(),
+        ],
       ),
     );
   }
 
   Widget _buildContactItemsList() {
     return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 25),
+      padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
       child: ListView.separated(
         physics: NeverScrollableScrollPhysics(),
         shrinkWrap: true,

--- a/lib/pages/contacts/contacts_data.dart
+++ b/lib/pages/contacts/contacts_data.dart
@@ -43,4 +43,11 @@ abstract class _ContactsData with Store {
       }
     });
   }
+
+  @action
+  Future<void> deleteContact(MultaccContact contact) async {
+    allContacts.remove(contact);
+    await _contactsBox.delete(contact.clientKey);
+    ContactsService.deleteContact(contact);
+  }
 }

--- a/lib/pages/contacts/contacts_page.dart
+++ b/lib/pages/contacts/contacts_page.dart
@@ -1,12 +1,11 @@
-import 'package:draggable_floating_button/draggable_floating_button.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:get_it/get_it.dart';
 import 'package:liquid_pull_to_refresh/liquid_pull_to_refresh.dart';
 import 'package:multacc/common/avatars.dart';
 import 'package:multacc/common/theme.dart';
+import 'package:multacc/database/contact_model.dart';
 import 'package:multacc/pages/contacts/contact_form_page.dart';
-import 'package:sliding_sheet/sliding_sheet.dart';
 import 'contact_details_page.dart';
 import 'contacts_data.dart';
 
@@ -80,42 +79,55 @@ class _ContactsPageState extends State<ContactsPage> with WidgetsBindingObserver
       } else if (selectedContacts.length > 0) {
         selectedContacts.add(index);
       } else {
-        showSlidingBottomSheet(
-          context,
-          builder: (context) => SlidingSheetDialog(
-            elevation: 8.0,
-            cornerRadius: 16.0,
-            color: kBackgroundColor,
-            snapSpec: const SnapSpec(
-              snap: true,
-              snappings: [0.6, 1.0],
-              positioning: SnapPositioning.relativeToAvailableSpace,
-            ),
-            builder: (context, state) => ContactDetailsPage(contactsData.allContacts[index]),
-            headerBuilder: (_, __) => // drag handle
-                Padding(padding: EdgeInsets.all(16.0), child: Icon(Icons.maximize, color: Colors.grey)),
-            footerBuilder: (context, state) => Row(
-              mainAxisAlignment: MainAxisAlignment.end,
-              children: <Widget>[
-                Padding(
-                  padding: const EdgeInsets.all(16.0),
-                  child: DraggableFloatingActionButton(
-                    offset: Offset(200, 200),
-                    backgroundColor: kPrimaryColor,
-                    child: Icon(Icons.edit),
-                    appContext: context,
-                    onPressed: () => Navigator.of(context).push(MaterialPageRoute(
-                      fullscreenDialog: true,
-                      builder: (context) => ContactFormPage(contact: contactsData.allContacts[index]),
-                    )),
+        MultaccContact contact = contactsData.allContacts[index];
+        Navigator.of(context).push(
+          MaterialPageRoute(
+            builder: (context) => Scaffold(
+              appBar: AppBar(
+                actions: <Widget>[
+                  IconButton(
+                    icon: Icon(Icons.delete),
+                    onPressed: () => _deleteContact(contact),
                   ),
-                )
-              ],
+                ],
+              ),
+              body: ContactDetailsPage(contactsData.allContacts[index]),
+              floatingActionButton: FloatingActionButton(
+                child: Icon(Icons.edit),
+                backgroundColor: kPrimaryColor,
+                onPressed: () => Navigator.of(context).push(MaterialPageRoute(
+                  fullscreenDialog: true,
+                  builder: (context) => ContactFormPage(contact: contact),
+                )),
+              ),
             ),
           ),
         );
       }
     });
+  }
+
+  void _deleteContact(MultaccContact contact) {
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8.0)),
+        title: Text('Delete this contact?'),
+        content: Text('${contact.displayName} will be permanently removed'),
+        actions: <Widget>[
+          FlatButton(child: Text('Cancel'), onPressed: () => Navigator.of(context).pop()),
+          FlatButton(
+            child: Text('Delete'),
+            onPressed: () {
+              contactsData.deleteContact(contact);
+              Navigator.of(context).pop();
+              Navigator.of(context).pop();
+            },
+          )
+        ],
+      ),
+    );
+    ;
   }
 
   // Quietly refresh contacts when returning to foreground

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,10 +16,8 @@ dependencies:
   google_fonts: any
   flutter_icons: any
   flutter_svg: any
-  sliding_sheet: any
   liquid_pull_to_refresh: any
   bubble: any
-  draggable_floating_button: any
   flutter_material_pickers: any
 
   # device APIs


### PR DESCRIPTION
- Added delete functionality (closes #200)
- Removed sliding sheet
  - Now uses a proper `MaterialPageRoute`
  - This thing was too slow anyway
  - Also fixes #63 since we don't care about the page height anymore
- Replaced draggable FAB with proper one
  - This fixes several tiny unexpected issues
  - Also adds a nice little transition

Note: The `ContactDetailsPage` is currently just a container, with the scaffold/appbar/fab located in `ContactsPage`. We want to fix this later but I left it as is because I don't know if it's being used in one of the three profile page implementations that we have going right now.