### PR TITLE
Remove default SMS hander capability

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.multacc">
-    
     <application
         android:label="Multacc"
         android:icon="@mipmap/launcher_icon"
@@ -11,9 +10,7 @@
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"
-            android:exported="true"
             android:windowSoftInputMode="adjustResize">
-            
             <!-- Specifies an Android theme to apply to this Activity as soon as
                  the Android process has started. This theme is visible to the user
                  while the Flutter UI initializes. After that, this theme continues
@@ -21,7 +18,7 @@
             <meta-data
               android:name="io.flutter.embedding.android.NormalTheme"
               android:resource="@style/NormalTheme"
-            />
+              />
             <!-- Displays an Android View that continues showing the launch screen
                  Drawable until Flutter paints its first frame, then this splash
                  screen fades out. A splash screen is useful to avoid any visual
@@ -30,56 +27,12 @@
             <meta-data
               android:name="io.flutter.embedding.android.SplashScreenDrawable"
               android:resource="@drawable/launch_background"
-            />
+              />
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
-                <action android:name="android.intent.action.SEND" />
-                <action android:name="android.intent.action.SENDTO" />
-                <action android:name="android.intent.action.VIEW" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-            </intent-filter>
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN"/>
-                <category android:name="android.intent.category.LAUNCHER"/>
-                <action android:name="android.intent.action.SEND" />
-                <action android:name="android.intent.action.SENDTO" />
-                <action android:name="android.intent.action.VIEW" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="sms" />
-                <data android:scheme="smsto" />
-                <data android:scheme="mms" />
-                <data android:scheme="mmsto" />
             </intent-filter>
         </activity>
-        <receiver android:name=".SmsReceiver"
-          android:permission="android.permission.BROADCAST_SMS">
-          <intent-filter>
-            <action android:name="android.provider.Telephony.SMS_RECEIVED" />
-            <action android:name="android.provider.Telephony.SMS_DELIVER" />
-          </intent-filter>
-        </receiver>
-        <receiver android:name=".MmsReceiver"
-          android:permission="android.permission.BROADCAST_WAP_PUSH">
-          <intent-filter>
-            <action android:name="android.provider.Telephony.WAP_PUSH_DELIVER" />
-            <data android:mimeType="application/vnd.wap.mms-message" />
-          </intent-filter>
-        </receiver>
-        <service android:name=".HeadlessSmsSendService"
-          android:permission="android.permission.SEND_RESPOND_VIA_MESSAGE"
-          android:exported="true" >
-          <intent-filter>
-            <action android:name="android.intent.action.RESPOND_VIA_MESSAGE" />
-            <category android:name="android.intent.category.DEFAULT" />
-            <data android:scheme="sms" />
-            <data android:scheme="smsto" />
-            <data android:scheme="mms" />
-            <data android:scheme="mmsto" />
-          </intent-filter>
-        </service>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data
@@ -89,14 +42,5 @@
 
   <uses-permission android:name="android.permission.READ_CONTACTS" />  
   <uses-permission android:name="android.permission.WRITE_CONTACTS" />
-  <uses-permission android:name="android.permission.SEND_SMS" />
-  <uses-permission android:name="android.permission.RECEIVE_SMS" />
-  <uses-permission android:name="android.permission.READ_SMS" />
-  <uses-permission android:name="android.permission.WRITE_SMS" />
-  <uses-permission android:name="android.permission.SEND_MMS" />
-  <uses-permission android:name="android.permission.RECEIVE_MMS" />
-  <uses-permission android:name="android.permission.RECEIVE_WAP_PUSH" />
-  <uses-permission android:name="android.permission.RESPOND_VIA_MESSAGE" />
-  <uses-permission android:name="android.permission.WAP_PUSH_DELIVER" />
-  
+
 </manifest>

--- a/android/app/src/main/kotlin/com/example/multacc/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/multacc/MainActivity.kt
@@ -1,39 +1,5 @@
 package com.multacc
 
-import androidx.annotation.NonNull
 import io.flutter.embedding.android.FlutterActivity
-import io.flutter.embedding.engine.FlutterEngine
-import io.flutter.plugin.common.MethodChannel
-import io.flutter.plugins.GeneratedPluginRegistrant;
 
-import android.content.Context
-import android.content.ContextWrapper
-import android.content.Intent
-import android.content.IntentFilter
-import android.os.BatteryManager
-import android.os.Build.VERSION
-import android.os.Build.VERSION_CODES
-import android.provider.Telephony
-
-import android.util.Log
-import io.flutter.plugin.common.PluginRegistry.Registrar
-
-class MainActivity: FlutterActivity() {
-  private val CHANNEL = "com.multacc/sms-handler"
-
-  override fun configureFlutterEngine(@NonNull flutterEngine: FlutterEngine) {
-    super.configureFlutterEngine(flutterEngine)
-
-    MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL).setMethodCallHandler {
-      call, result ->
-      if(call.method == "defaultSMS"){
-        val setSmsAppIntent = Intent(Telephony.Sms.Intents.ACTION_CHANGE_DEFAULT)
-        setSmsAppIntent.putExtra(Telephony.Sms.Intents.EXTRA_PACKAGE_NAME, packageName)
-        startActivityForResult(setSmsAppIntent, 1)
-      }
-      else {
-        result.notImplemented()
-      }
-    }
-  }
-}
+class MainActivity: FlutterActivity() {}

--- a/android/settings_aar.gradle
+++ b/android/settings_aar.gradle
@@ -1,1 +1,0 @@
-include ':app'

--- a/lib/pages/settings/settings_page.dart
+++ b/lib/pages/settings/settings_page.dart
@@ -1,12 +1,10 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_package_manager/flutter_package_manager.dart';
 import 'package:flutter_statusbarcolor/flutter_statusbarcolor.dart';
 import 'package:get_it/get_it.dart';
 import 'package:multacc/common/constants.dart';
 import 'package:multacc/common/theme.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:permission_handler/permission_handler.dart';
 
 class SettingsPage extends StatefulWidget {
   SettingsPage() {
@@ -19,8 +17,6 @@ class SettingsPage extends StatefulWidget {
 
 class _SettingsPageState extends State<SettingsPage> {
   SharedPreferences prefs;
-
-  static const platform = const MethodChannel('com.multacc/sms-handler');
 
   @override
   void initState() {
@@ -39,10 +35,6 @@ class _SettingsPageState extends State<SettingsPage> {
         child: Column(
           children: <Widget>[
             _buildPhoneAppTile(context),
-            RaisedButton(
-              child: Text('Set Default SMS App'),
-              onPressed: _defaultSMS,
-            ),
             // @todo Add setting for redirecting calls to preferred dialer through multacc
           ],
         ),
@@ -101,17 +93,5 @@ class _SettingsPageState extends State<SettingsPage> {
     setState(() {
       prefs.setString('PHONE_APP', value);
     });
-  }
-
-
-  Future<void> _defaultSMS() async {
-
-    try {
-      await platform.invokeMethod('defaultSMS');
-    } catch (e) {
-      print(e);
-    }
-
-    while(!await Permission.sms.request().isGranted){}
   }
 }


### PR DESCRIPTION
Revert "Add handler for making multacc the default SMS app (#198)"
_This reverts commit 920bd314cd317f986ec19da75083f2728baf0b9b._

In its current state, the app will "lose" any incoming SMS if set as the default handler. When/if the follow-up PR (#202) to fix everything does happen, it will include the changes from #198 anyway.

Also see #178.

More importantly, Google rejected Multacc when submitted to the Play Store because it requests SMS permissions and doesn't actually use them.