### PR TITLE
Add release signing config to build.gradle

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -26,6 +26,12 @@ apply plugin: 'com.google.gms.google-services'
 apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
+def keystoreProperties = new Properties()
+def keystorePropertiesFile = rootProject.file('key.properties')
+if (keystorePropertiesFile.exists()) {
+    keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+}
+
 android {
     compileSdkVersion 29
 
@@ -46,13 +52,20 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
-    buildTypes {
-        release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig signingConfigs.debug
-        }
-    }
+    signingConfigs {
+       release {
+           keyAlias keystoreProperties['keyAlias']
+           keyPassword keystoreProperties['keyPassword']
+           storeFile keystoreProperties['storeFile'] ? file(keystoreProperties['storeFile']) : null
+           storePassword keystoreProperties['storePassword']
+       }
+   }
+   
+   buildTypes {
+       release {
+           signingConfig signingConfigs.release
+       }
+   }
 }
 
 flutter {
@@ -66,4 +79,5 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'
     implementation 'com.google.firebase:firebase-auth:19.2.0'
     implementation 'com.google.guava:guava:29.0-android'
+    implementation 'com.google.android.gms:play-services-auth:18.0.0'
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: multacc
 description: multiple accounts
 
-version: 0.0.5+5
+version: 0.0.5+7
 
 environment:
   sdk: ">=2.6.0 <3.0.0"


### PR DESCRIPTION
`build.gradle` now has a proper signing config for release builds. Uses a `keys.properties` file that gets generated in Codemagic)

This should theoretically close #235 

Additionally:
- The firebase console now has new release fingerprints from the Google Play Console. So `google-services.json` has been updated.
- The keystore has been updated with upload certificate from Google Play Console.